### PR TITLE
Add FOCI'20 papers.

### DIFF
--- a/header.tpl
+++ b/header.tpl
@@ -180,7 +180,7 @@
       <div class="menu-item">
         <img class="top-icon" src="img/update-icon.svg" alt="update icon"/>
         <a
-        href="https://github.com/NullHypothesis/censorbib/commits/master">Last update: 2020-07-20</a>
+        href="https://github.com/NullHypothesis/censorbib/commits/master">Last update: 2020-08-13</a>
       </div>
       <div class="menu-item">
         <img class="top-icon" src="img/donate-icon.svg" alt="donate icon"/>

--- a/references.bib
+++ b/references.bib
@@ -1,3 +1,66 @@
+@inproceedings{Alharbi2020a,
+	author = {Fatemah Alharbi and Michalis Faloutsos and Nael Abu-Ghazaleh},
+	title = {Opening Digital Borders Cautiously yet Decisively: Digital Filtering in {Saudi} {Arabia}},
+	booktitle = {Free and Open Communications on the Internet},
+	publisher = {USENIX},
+	year = {2020},
+	url = {https://www.usenix.org/system/files/foci20-paper-alharbi_0.pdf},
+}
+
+@inproceedings{Bock2020a,
+	author = {Kevin Bock and Yair Fax and Kyle Reese and Jasraj Singh and Dave Levin},
+	title = {Detecting and Evading Censorship-in-Depth: A Case Study of {Iran}’s Protocol Whitelister},
+	booktitle = {Free and Open Communications on the Internet},
+	publisher = {USENIX},
+	year = {2020},
+	url = {https://www.usenix.org/system/files/foci20-paper-bock.pdf},
+}
+
+@inproceedings{Anonymous2020a,
+	author = {Anonymous and Arian Akhavan Niaki and Nguyen Phong Hoang and Phillipa Gill and Amir Houmansadr},
+	title = {Triplet Censors: Demystifying {Great} {Firewall}’s {DNS} Censorship Behavior},
+	booktitle = {Free and Open Communications on the Internet},
+	publisher = {USENIX},
+	year = {2020},
+	url = {https://www.usenix.org/system/files/foci20-paper-anonymous_0.pdf},
+}
+
+@inproceedings{Birtel2020a,
+	author = {Benedikt Birtel and Christian Rossow},
+	title = {{Slitheen}++: Stealth {TLS}-based Decoy Routing},
+	booktitle = {Free and Open Communications on the Internet},
+	publisher = {USENIX},
+	year = {2020},
+	url = {https://www.usenix.org/system/files/foci20-paper-birtel_0.pdf},
+}
+
+@inproceedings{Fifield2020a,
+	author = {David Fifield},
+	title = {{Turbo} {Tunnel}, a good way to design censorship circumvention protocols},
+	booktitle = {Free and Open Communications on the Internet},
+	publisher = {USENIX},
+	year = {2020},
+	url = {https://www.usenix.org/system/files/foci20-paper-fifield.pdf},
+}
+
+@inproceedings{Frolov2020b,
+	author = {Sergey Frolov and Eric Wustrow},
+	title = {{HTTPT}: A Probe-Resistant Proxy},
+	booktitle = {Free and Open Communications on the Internet},
+	publisher = {USENIX},
+	year = {2020},
+	url = {https://www.usenix.org/system/files/foci20-paper-frolov.pdf},
+}
+
+@inproceedings{Govil2020a,
+	author = {Yashodhar Govil and Liang Wang and Jennifer Rexford},
+	title = {{MIMIQ}: Masking {IP}s with Migration in {QUIC}},
+	booktitle = {Free and Open Communications on the Internet},
+	publisher = {USENIX},
+	year = {2020},
+	url = {https://www.usenix.org/system/files/foci20-paper-govil.pdf},
+}
+
 @inproceedings{Singh2020a,
 	author = {Kushagra Singh and Gurshabad Grover and Varun Bansal},
 	title = {How {India} Censors the Web},


### PR DESCRIPTION
All papers in the `Censorship Detection` and `New Directions in Evasion` [sessions](https://www.usenix.org/conference/foci20/workshop-program) are included.