### PR TITLE
Fix all seven broken links and bypass HTTP 403 on NDSS

### DIFF
--- a/fetch_pdfs.py
+++ b/fetch_pdfs.py
@@ -34,7 +34,8 @@ def download_pdf(url, file_name):
     print("Now fetching %s" % url)
 
     try:
-        fetched_file = urllib.request.urlopen(url)
+        req = urllib.request.Request(url, headers={'User-Agent': "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/99.0.4844.84 Safari/537.36"})
+        fetched_file = urllib.request.urlopen(req)
     except Exception as err:
         print(url, err, file=sys.stderr)
         return

--- a/fetch_pdfs.py
+++ b/fetch_pdfs.py
@@ -36,7 +36,7 @@ def download_pdf(url, file_name):
     try:
         fetched_file = urllib.request.urlopen(url)
     except Exception as err:
-        print(err, file=sys.stderr)
+        print(url, err, file=sys.stderr)
         return
 
     with open(file_name, "wb") as fd:

--- a/references.bib
+++ b/references.bib
@@ -33,7 +33,7 @@
 	number = {4},
 	publisher = {National Academy of Sciences},
 	year = {2022},
-	url = {https://www.pnas.org/content/pnas/119/4/e2102818119.full.pdf},
+	url = {https://censorbib.nymity.ch/pdf/Chang2022a.pdf},
 }
 
 @inproceedings{Kaptchuk2021a,
@@ -530,7 +530,7 @@
 	booktitle = {Intelligent Human-Machine Systems and Cybernetics},
 	publisher = {IEEE},
 	year = {2017},
-	url = {https://www.directory-root.com/wp-content/uploads/2018/02/Shadowsocks-Sniffing.pdf},
+	url = {https://censorbib.nymity.ch/pdf/Deng2017a.pdf},
 }
 
 @inproceedings{Yadav2018a,
@@ -1185,7 +1185,7 @@
 	booktitle = {International Conference on Web and Social Media},
 	publisher = {AAAI},
 	year = {2015},
-	url = {https://comp.social.gatech.edu/papers/icwsm15.algorithmically.hiruncharoenvate.pdf},
+	url = {https://censorbib.nymity.ch/pdf/Hiruncharoenvate2015a.pdf},
 }
 
 @inproceedings{Nisar2015a,
@@ -1360,7 +1360,7 @@
 	booktitle = {On the Move to Meaningful Internet Systems},
 	publisher = {Springer},
 	year = {2009},
-	url = {https://sps.cs.uni-saarland.de/maffei/resources/coopis.pdf},
+	url = {https://censorbib.nymity.ch/pdf/Backes2009a.pdf},
 }
 
 @inproceedings{Wang2014a,
@@ -1760,7 +1760,7 @@
 	publisher = {ACM},
 	title = {{Cirripede}: Circumvention Infrastructure using Router Redirection with Plausible Deniability},
 	year = {2011},
-	url = {https://hatswitch.org/~nikita/papers/cirripede-ccs11.pdf},
+	url = {https://people.cs.umass.edu/~amir/papers/CCS11-Cirripede.pdf},
 }
 
 @inproceedings{Houmansadr2013a,
@@ -2206,7 +2206,7 @@
 	booktitle = {Computer and Communications Security},
 	publisher = {ACM},
 	year = {2012},
-	url = {https://hatswitch.org/~nikita/papers/censorspoofer.pdf},
+	url = {https://censorbib.nymity.ch/pdf/Wang2012a.pdf},
 }
 
 @inproceedings{Wang2013a,
@@ -2241,7 +2241,7 @@
 	title = {{Dust}: A Blocking-Resistant {Internet} Transport Protocol},
 	institution = {University of Texas at Austin},
 	year = {2011},
-	url = {http://blanu.net/Dust.pdf},
+	url = {http://censorbib.nymity.ch/pdf/Wiley2011a.pdf},
 }
 
 @inproceedings{Winter2012a,


### PR DESCRIPTION
This pull request includes the following three changes:

* Fix all seven broken links.
* Bypass HTTP 403 on NDSS websites with the latest Chrome user agent.
* Show which url fails to request.