### PR TITLE
Add one CoNext'22 paper.

### DIFF
--- a/header.tpl
+++ b/header.tpl
@@ -181,7 +181,7 @@
       <div class="menu-item">
         <img class="top-icon" src="img/update-icon.svg" alt="update icon"/>
         <a
-        href="https://github.com/NullHypothesis/censorbib/commits/master">Last update: 2022-10-27</a>
+        href="https://github.com/NullHypothesis/censorbib/commits/master">Last update: 2022-12-14</a>
       </div>
       <div class="menu-item">
         <img class="top-icon" src="img/donate-icon.svg" alt="donate icon"/>

--- a/references.bib
+++ b/references.bib
@@ -1,3 +1,12 @@
+@inproceedings{Raman2022a,
+	author = {Ram Sundara Raman and Mona Wang and Jakub Dalek and Jonathan Mayer and Roya Ensafi},
+	title = {Network Measurement Methods for Locating and Examining Censorship Devices},
+	booktitle = {Emerging Networking Experiments and Technologies},
+	publisher = {ACM},
+	year = {2022},
+	url = {https://dl.acm.org/doi/pdf/10.1145/3555050.3569133},
+}
+
 @inproceedings{Xue2022b,
 	author = {Diwen Xue and Benjamin Mixon-Baca and ValdikSS and Anna Ablove and Beau Kujath and Jedidiah R. Crandall and Roya Ensafi},
 	title = {{TSPU}: {Russia}'s Decentralized Censorship System},


### PR DESCRIPTION
Information related to this paper: 

* CoNext'22: https://conferences2.sigcomm.org/co-next/2022/#!/program
* Paper: https://dl.acm.org/doi/10.1145/3555050.3569133
* Project page: https://censoredplanet.org/censorship-devices
* Blog post: https://www.opentech.fund/news/profiling-internet-censors-methods-to-measure-and-locate-censorship-devices/