### PR TITLE
Add four FOCI'23 papers.

### DIFF
--- a/header.tpl
+++ b/header.tpl
@@ -181,7 +181,7 @@
       <div class="menu-item">
         <img class="top-icon" src="img/update-icon.svg" alt="update icon"/>
         <a
-        href="https://github.com/NullHypothesis/censorbib/commits/master">Last update: 2022-12-14</a>
+        href="https://github.com/NullHypothesis/censorbib/commits/master">Last update: 2023-02-25/a>
       </div>
       <div class="menu-item">
         <img class="top-icon" src="img/donate-icon.svg" alt="donate icon"/>

--- a/references.bib
+++ b/references.bib
@@ -1,3 +1,39 @@
+@inproceedings{Katira2023a,
+	author = {Divyank Katira and Gurshabad Grover and Kushagra Singh and Varun Bansal},
+	title = {{CensorWatch}: On the Implementation of Online Censorship in {India}},
+	booktitle = {Free and Open Communications on the Internet},
+	publisher = {},
+	year = {2023},
+	url = {https://www.petsymposium.org/foci/2023/foci-2023-0006.pdf},
+}
+
+@inproceedings{Wang2023a,
+	author = {Gaukas Wang and Anonymous and Jackson Sippe and Hai Chi and Eric Wustrow},
+	title = {Chasing Shadows: A security analysis of the {ShadowTLS} proxy},
+	booktitle = {Free and Open Communications on the Internet},
+	publisher = {},
+	year = {2023},
+	url = {https://www.petsymposium.org/foci/2023/foci-2023-0002.pdf},
+}
+
+@inproceedings{Fenske2023a,
+	author = {Ellis Fenske and Aaron Johnson},
+	title = {Security Notions for Fully Encrypted Protocols},
+	booktitle = {Free and Open Communications on the Internet},
+	publisher = {},
+	year = {2023},
+	url = {https://www.petsymposium.org/foci/2023/foci-2023-0004.pdf},
+}
+
+@inproceedings{Raman2023a,
+	author = {Ram Sundara Raman and Apurva Virkud and Sarah Laplante and Vinicius Fortuna and Roya Ensafi},
+	title = {Advancing the Art of Censorship Data Analysis},
+	booktitle = {Free and Open Communications on the Internet},
+	publisher = {},
+	year = {2023},
+	url = {https://www.petsymposium.org/foci/2023/foci-2023-0003.pdf},
+}
+
 @inproceedings{Raman2022a,
 	author = {Ram Sundara Raman and Mona Wang and Jakub Dalek and Jonathan Mayer and Roya Ensafi},
 	title = {Network Measurement Methods for Locating and Examining Censorship Devices},


### PR DESCRIPTION
I only selected FOC'23 papers that are directly related to Internet censorship. A full list of FOCI'23 papers are available at: https://github.com/net4people/bbs/issues/206. 

I left the publisher fields empty as I have not been able to find related information.