### PR TITLE
Add one USENIX SECURITY'23 paper.

### DIFF
--- a/header.tpl
+++ b/header.tpl
@@ -189,7 +189,7 @@
           <div class="menu-item">
             <img class="top-icon" src="img/update-icon.svg" alt="update icon"/>
             <a
-            href="https://github.com/NullHypothesis/censorbib/commits/master">Last update: 2023-02-26</a>
+            href="https://github.com/NullHypothesis/censorbib/commits/master">Last update: 2023-04-20</a>
           </div>
           <div class="menu-item">
             <img class="top-icon" src="img/donate-icon.svg" alt="donate icon"/>

--- a/references.bib
+++ b/references.bib
@@ -1,3 +1,12 @@
+@inproceedings{Wu2023a,
+	author = {Mingshi Wu and Jackson Sippe and Danesh Sivakumar and Jack Burg and Peter Anderson and Xiaokang Wang and Kevin Bock and Amir Houmansadr and Dave Levin and Eric Wustrow},
+	title = {How the {Great Firewall} of {China} Detects and Blocks Fully Encrypted Traffic},
+	booktitle = {USENIX Security Symposium},
+	publisher = {USENIX},
+	year = {2023},
+	url = {https://www.usenix.org/system/files/sec23fall-prepub-234-wu-mingshi.pdf},
+}
+
 @article{Tulloch2023a,
 	author = {Lindsey Tulloch and Ian Goldberg},
 	title = {Lox: Protecting the Social Graph in Bridge Distribution},


### PR DESCRIPTION
Selected from: https://www.usenix.org/conference/usenixsecurity23/fall-accepted-papers

* PDF: https://www.usenix.org/system/files/sec23fall-prepub-234-wu-mingshi.pdf
* Artifacts: https://github.com/gfw-report/usenixsecurity23-artifact
* Homepage: https://gfw.report/publications/usenixsecurity23/en