### PR TITLE
Add one S&P'24 paper, one NDSS'24 paper, and one USENIX Security'24 paper.

### DIFF
--- a/header.tpl
+++ b/header.tpl
@@ -189,7 +189,7 @@
           <div class="menu-item">
             <img class="top-icon" src="img/update-icon.svg" alt="update icon"/>
             <a
-            href="https://github.com/NullHypothesis/censorbib/commits/master">Last update: 2023-09-16</a>
+            href="https://github.com/NullHypothesis/censorbib/commits/master">Last update: 2023-12-1</a>
           </div>
           <div class="menu-item">
             <img class="top-icon" src="img/donate-icon.svg" alt="donate icon"/>

--- a/references.bib
+++ b/references.bib
@@ -1,3 +1,12 @@
+@inproceedings{Kon2024a,
+	author = {Patrick Tser Jern Kon and Aniket Gattani and Dhiraj Saharia and Tianyu Cao and Diogo Barradas and Ang Chen and Micah Sherr and Benjamin E. Ujcich},
+	title = {{NetShuffle}: Circumventing Censorship with Shuffle Proxies at the Edge},
+	booktitle = {Symposium on Security \& Privacy},
+	publisher = {IEEE},
+	year = {2024},
+	url = {https://www.computer.org/csdl/pds/api/csdl/proceedings/download-article/1RjEabCelaM/pdf},
+}
+
 @inproceedings{Wails2024a,
 	author = {Ryan Wails and George Arnold Sullivan and Micah Sherr and Rob Jansen},
 	title = {On Precisely Detecting Censorship Circumvention in Real-World Networks},

--- a/references.bib
+++ b/references.bib
@@ -1,3 +1,13 @@
+@inproceedings{Wails2024a,
+	author = {Ryan Wails and George Arnold Sullivan and Micah Sherr and Rob Jansen},
+	title = {On Precisely Detecting Censorship Circumvention in Real-World Networks},
+	booktitle = {Network and Distributed System Security},
+	publisher = {The Internet Society},
+	year = {2024},
+	url = {https://www.robgjansen.com/publications/precisedetect-ndss2024.pdf},
+}
+
+
 @techreport{Fifield2023b,
 	author = {David Fifield},
 	title = {Comments on certain past cryptographic flaws affecting fully encrypted censorship circumvention protocols},

--- a/references.bib
+++ b/references.bib
@@ -1,3 +1,12 @@
+@inproceedings{Xue2023a,
+	author     = {Diwen Xue and Michalis Kallitsis and Amir Houmansadr and Roya Ensafi},
+	title      = {Fingerprinting Obfuscated Proxy Traffic with Encapsulated {TLS} Handshakes},
+	booktitle  = {USENIX Security Symposium},
+	publisher  = {USENIX},
+	year       = {2024},
+	url        = {https://www.usenix.org/system/files/sec24summer-prepub-465-xue.pdf},
+}
+
 @inproceedings{Kon2024a,
 	author = {Patrick Tser Jern Kon and Aniket Gattani and Dhiraj Saharia and Tianyu Cao and Diogo Barradas and Ang Chen and Micah Sherr and Benjamin E. Ujcich},
 	title = {{NetShuffle}: Circumventing Censorship with Shuffle Proxies at the Edge},


### PR DESCRIPTION
Paper related information:

**On Precisely Detecting Censorship Circumvention in Real-World Networks**
* Homepage: https://www.robgjansen.com/publications/precisedetect-ndss2024.html
* Reading group: https://github.com/net4people/bbs/issues/312