### PR TITLE
Add five FOCI'24 papers and correct the year of a publication

### DIFF
--- a/header.tpl
+++ b/header.tpl
@@ -188,7 +188,7 @@
           </div>
           <div class="menu-item">
             <img class="top-icon" src="img/update-icon.svg" alt="update icon"/>
-            <a href="https://github.com/NullHypothesis/censorbib/commits/master">Last update: 2024-02-17</a>
+            <a href="https://github.com/NullHypothesis/censorbib/commits/master">Last update: 2024-02-25</a>
           </div>
           <div class="menu-item">
             <img class="top-icon" src="img/donate-icon.svg" alt="donate icon"/>

--- a/header.tpl
+++ b/header.tpl
@@ -188,7 +188,7 @@
           </div>
           <div class="menu-item">
             <img class="top-icon" src="img/update-icon.svg" alt="update icon"/>
-            <a href="https://github.com/NullHypothesis/censorbib/commits/master">Last update: 2023-12-01</a>
+            <a href="https://github.com/NullHypothesis/censorbib/commits/master">Last update: 2024-02-17</a>
           </div>
           <div class="menu-item">
             <img class="top-icon" src="img/donate-icon.svg" alt="donate icon"/>

--- a/references.bib
+++ b/references.bib
@@ -1,4 +1,4 @@
-@inproceedings{Xue2023b,
+@inproceedings{Xue2024a,
 	author     = {Diwen Xue and Michalis Kallitsis and Amir Houmansadr and Roya Ensafi},
 	title      = {Fingerprinting Obfuscated Proxy Traffic with Encapsulated {TLS} Handshakes},
 	booktitle  = {USENIX Security Symposium},

--- a/references.bib
+++ b/references.bib
@@ -1,3 +1,48 @@
+@inproceedings{Kristoff2024a,
+	author = {John Kristoff and Max Resing and Moritz M\"{u}eller and Arturo Filast\`{o} and Chris Kanich and Niels ten Oever},
+	title = {{Internet} Sanctions on {Russian} Media: Implementation and Effects},
+	booktitle = {Free and Open Communications on the Internet},
+	publisher = {},
+	year = {2024},
+	url = {https://www.petsymposium.org/foci/2024/foci-2024-0001.pdf},
+}
+
+@inproceedings{Sakamoto2024a,
+	author = {Sakamoto and Elson Wedwards},
+	title = {Bleeding Wall: A Hematologic Examination on the {Great Firewall}},
+	booktitle = {Free and Open Communications on the Internet},
+	publisher = {},
+	year = {2024},
+	url = {https://www.petsymposium.org/foci/2024/foci-2024-0002.pdf},
+}
+
+@inproceedings{Chi2024a,
+	author = {Erik Chi and Gaukas Wang and J. Alex Halderman and Eric Wustrow and Jack Wampler},
+	title = {Just add {WATER}: WebAssembly-based Circumvention Transports},
+	booktitle = {Free and Open Communications on the Internet},
+	publisher = {},
+	year = {2024},
+	url = {https://www.petsymposium.org/foci/2024/foci-2024-0003.pdf},
+}
+
+@inproceedings{Lorimer2024a,
+	author = {Anna Harbluk Lorimer and Rob Jansen and Nick Feamster},
+	title = {Extended Abstract: Traffic Splitting for Pluggable Transports},
+	booktitle = {Free and Open Communications on the Internet},
+	publisher = {},
+	year = {2024},
+	url = {https://www.petsymposium.org/foci/2024/foci-2024-0004.pdf},
+}
+
+@inproceedings{Chen2024a,
+	author = {Mingye Chen and Jack Wampler and Abdulrahman Alaraj and Gaukas Wang and Eric Wustrow},
+	title = {Extended Abstract: {Oscur0}: One-shot Circumvention without registration},
+	booktitle = {Free and Open Communications on the Internet},
+	publisher = {},
+	year = {2024},
+	url = {https://www.petsymposium.org/foci/2024/foci-2024-0005.php},
+}
+
 @inproceedings{Xue2024a,
 	author     = {Diwen Xue and Michalis Kallitsis and Amir Houmansadr and Roya Ensafi},
 	title      = {Fingerprinting Obfuscated Proxy Traffic with Encapsulated {TLS} Handshakes},
@@ -84,6 +129,7 @@
 	year       = {2023},
 	url        = {https://doi.ieeecomputersociety.org/10.1109/SP46215.2023.00183},
 }
+
 @inproceedings{Master2023a,
 	author = {Alexander Master and Christina Garman},
 	title = {A Worldwide View of Nation-state {Internet} Censorship},

--- a/references.bib
+++ b/references.bib
@@ -8,8 +8,8 @@
 }
 
 @inproceedings{Kristoff2024a,
-	author = {John Kristoff and Max Resing and Moritz M\"{u}eller and Arturo Filast\`{o} and Chris Kanich and Niels ten Oever},
-	title = {{Internet} Sanctions on {Russian} Media: Implementation and Effects},
+	author = {John Kristoff and Moritz M\"{u}eller and Arturo Filast\`{o} and Max Resing and Chris Kanich and Niels ten Oever},
+	title = {{Internet} Sanctions on {Russian} Media: Actions and Effects},
 	booktitle = {Free and Open Communications on the Internet},
 	publisher = {},
 	year = {2024},
@@ -27,7 +27,7 @@
 
 @inproceedings{Chi2024a,
 	author = {Erik Chi and Gaukas Wang and J. Alex Halderman and Eric Wustrow and Jack Wampler},
-	title = {Just add {WATER}: WebAssembly-based Circumvention Transports},
+	title = {Just add {WATER}: {WebAssembly}-based Circumvention Transports},
 	booktitle = {Free and Open Communications on the Internet},
 	publisher = {},
 	year = {2024},
@@ -45,11 +45,11 @@
 
 @inproceedings{Chen2024a,
 	author = {Mingye Chen and Jack Wampler and Abdulrahman Alaraj and Gaukas Wang and Eric Wustrow},
-	title = {Extended Abstract: {Oscur0}: One-shot Circumvention without registration},
+	title = {Extended Abstract: {Oscur0}: One-shot Circumvention without Registration},
 	booktitle = {Free and Open Communications on the Internet},
 	publisher = {},
 	year = {2024},
-	url = {https://www.petsymposium.org/foci/2024/foci-2024-0005.php},
+	url = {https://www.petsymposium.org/foci/2024/foci-2024-0005.pdf},
 }
 
 @inproceedings{Xue2024a,

--- a/references.bib
+++ b/references.bib
@@ -1,3 +1,12 @@
+@inproceedings{2024a,
+	author = {Elisa Tsai and Ram Sundara Raman and Atul Prakash and Roya Ensafi},
+	title = {Modeling and Detecting {Internet} Censorship Events},
+	booktitle = {Network and Distributed System Security},
+	publisher = {The Internet Society},
+	year = {2024},
+	url = {https://www.ndss-symposium.org/wp-content/uploads/2024-409-paper.pdf},
+}
+
 @inproceedings{Kristoff2024a,
 	author = {John Kristoff and Max Resing and Moritz M\"{u}eller and Arturo Filast\`{o} and Chris Kanich and Niels ten Oever},
 	title = {{Internet} Sanctions on {Russian} Media: Implementation and Effects},

--- a/references.bib
+++ b/references.bib
@@ -1,4 +1,4 @@
-@inproceedings{2024a,
+@inproceedings{Tsai2024a,
 	author = {Elisa Tsai and Ram Sundara Raman and Atul Prakash and Roya Ensafi},
 	title = {Modeling and Detecting {Internet} Censorship Events},
 	booktitle = {Network and Distributed System Security},


### PR DESCRIPTION
This pull request adds three papers and two extended abstracts from FOCI'24. It also corrects the year of a publication.

* Homepage: https://foci.community/foci24.html
* Publications: https://www.petsymposium.org/foci/2024/
* Discussion group: https://github.com/net4people/bbs/issues/329


