### PR TITLE
Add reading group links on Net4People BBS and traffic-obf mailing list

### DIFF
--- a/references.bib
+++ b/references.bib
@@ -146,6 +146,7 @@
 	publisher = {The Internet Society},
 	year = {2024},
 	url = {https://www.robgjansen.com/publications/precisedetect-ndss2024.pdf},
+	discussion_url = {https://github.com/net4people/bbs/issues/312},
 }
 
 @article{Ververis2023a,
@@ -233,6 +234,7 @@
 	publisher  = {ACM},
 	year       = {2023},
 	url        = {https://dl.acm.org/doi/abs/10.1145/3543507.3583189},
+	discussion_url = {https://github.com/net4people/bbs/issues/273},
 }
 
 @inproceedings{Nourin2023b,
@@ -251,6 +253,7 @@
 	publisher = {},
 	year = {2023},
 	url = {https://www.petsymposium.org/foci/2023/foci-2023-0011.pdf},
+	discussion_url = {https://github.com/net4people/bbs/issues/222},
 }
 
 @inproceedings{Ortwein2023a,
@@ -334,6 +337,7 @@
 	publisher = {},
 	year = {2023},
 	url = {https://petsymposium.org/popets/2023/popets-2023-0029.pdf},
+	discussion_url = {https://github.com/net4people/bbs/issues/320},
 }
 
 @article{Sharma2023a,
@@ -354,6 +358,7 @@
 	publisher = {},
 	year = {2023},
 	url = {https://www.petsymposium.org/foci/2023/foci-2023-0006.pdf},
+	discussion_url = {https://github.com/net4people/bbs/issues/360},
 }
 
 @inproceedings{Wang2023a,
@@ -363,6 +368,7 @@
 	publisher = {},
 	year = {2023},
 	url = {https://www.petsymposium.org/foci/2023/foci-2023-0002.pdf},
+	disussion_url = {https://github.com/net4people/bbs/issues/322},
 }
 
 @inproceedings{Fenske2023a,
@@ -444,6 +450,7 @@
 	publisher = {ACM},
 	year = {2022},
 	url = {https://dl.acm.org/doi/pdf/10.1145/3488932.3517419},
+	disussion_url = {https://github.com/net4people/bbs/issues/259},
 }
 
 @inproceedings{Gosain2017b,
@@ -501,6 +508,7 @@
 	publisher = {ACM},
 	year = {2021},
 	url = {https://www.cs.jhu.edu/~gkaptch1/publications/ccs21_meteor.pdf},
+	disussion_url = {https://github.com/net4people/bbs/issues/104},
 }
 
 @inproceedings{Xue2021a,
@@ -519,6 +527,7 @@
 	publisher = {ACM},
 	year = {2021},
 	url = {https://dl.acm.org/doi/pdf/10.1145/3487552.3487836},
+	discussion_url = {https://github.com/net4people/bbs/issues/113},
 }
 
 @inproceedings{Basso2021a,
@@ -546,6 +555,7 @@
 	publisher = {ACM},
 	year = {2021},
 	url = {https://doi.org/10.1145/3473604.3474560},
+	disucssion_url = {https://github.com/net4people/bbs/issues/95},
 }
 
 @inproceedings{Kwan2021a,
@@ -555,6 +565,7 @@
 	publisher = {ACM},
 	year = {2021},
 	url = {https://doi.org/10.1145/3473604.3474563},
+	discussion_url = {https://github.com/net4people/bbs/issues/94},
 }
 
 @inproceedings{Bock2021c,
@@ -573,6 +584,7 @@
 	publisher = {ACM},
 	year = {2021},
 	url = {https://doi.org/10.1145/3473604.3474564},
+	discussion_url = {https://github.com/net4people/bbs/issues/86},
 }
 
 @inproceedings{Wei2021a,
@@ -582,6 +594,7 @@
 	publisher = {USENIX},
 	year = {2021},
 	url = {https://www.usenix.org/system/files/sec21-wei.pdf},
+	discussion_url = {https://github.com/net4people/bbs/issues/73},
 }
 
 @inproceedings{Bock2021b,
@@ -591,6 +604,7 @@
 	publisher = {USENIX},
 	year = {2021},
 	url = {https://www.usenix.org/system/files/sec21-bock.pdf},
+	disucssion_url = {https://github.com/net4people/bbs/issues/121},
 }
 
 @inproceedings{Hoang2021a,
@@ -609,6 +623,7 @@
 	publisher = {USENIX},
 	year = {2021},
 	url = {https://www.usenix.org/system/files/sec21-rosen.pdf},
+	discussion_url = {https://github.com/net4people/bbs/issues/112},
 }
 
 @inproceedings{Bock2021a,
@@ -629,6 +644,7 @@
 	publisher = {Sciendo},
 	year = {2021},
 	url = {https://petsymposium.org/2021/files/papers/issue2/popets-2021-0023.pdf},
+	discussion_url = {https://github.com/net4people/bbs/issues/90},
 }
 
 @inproceedings{Barradas2020b,
@@ -638,6 +654,7 @@
 	publisher = {ACM},
 	year = {2020},
 	url = {https://www.gsd.inesc-id.pt/~nsantos/papers/barradas_dicg20.pdf},
+	disussion_url = {https://github.com/net4people/bbs/issues/258},
 }
 
 @inproceedings{Barradas2020a,
@@ -647,6 +664,7 @@
 	publisher = {ACM},
 	year = {2020},
 	url = {https://www.gsd.inesc-id.pt/~nsantos/papers/barradas_ccs20.pdf},
+	discussion_url = {https://github.com/net4people/bbs/issues/55},
 }
 
 @inproceedings{Raman2020c,
@@ -656,6 +674,7 @@
 	publisher = {ACM},
 	year = {2020},
 	url = {https://www.ramakrishnansr.com/assets/censoredplanet.pdf},
+	discussion_url = {https://github.com/net4people/bbs/issues/283},
 }
 
 @inproceedings{Alice2020a,
@@ -674,6 +693,7 @@
 	publisher = {ACM},
 	year = {2020},
 	url = {https://dl.acm.org/doi/pdf/10.1145/3419394.3423665},
+	discussion_url = {https://github.com/net4people/bbs/issues/66},
 }
 
 @inproceedings{Bock2020b,
@@ -701,6 +721,7 @@
 	publisher = {USENIX},
 	year = {2020},
 	url = {https://www.usenix.org/system/files/foci20-paper-alharbi_0.pdf},
+	discussion_url = {https://github.com/net4people/bbs/issues/48},
 }
 
 @inproceedings{Anonymous2020a,
@@ -710,6 +731,7 @@
 	publisher = {USENIX},
 	year = {2020},
 	url = {https://www.usenix.org/system/files/foci20-paper-anonymous_0.pdf},
+	disussion_url = {https://github.com/net4people/bbs/issues/47},
 }
 
 @inproceedings{Birtel2020a,
@@ -728,6 +750,7 @@
 	publisher = {USENIX},
 	year = {2020},
 	url = {https://www.usenix.org/system/files/foci20-paper-bock.pdf},
+	discussion_url = {https://github.com/net4people/bbs/issues/49},
 }
 
 @inproceedings{Fifield2020a,
@@ -746,6 +769,7 @@
 	publisher = {USENIX},
 	year = {2020},
 	url = {https://www.usenix.org/system/files/foci20-paper-frolov.pdf},
+	disussion_url = {https://github.com/net4people/bbs/issues/50},
 }
 
 @inproceedings{Singh2020a,
@@ -766,6 +790,7 @@
 	publisher = {ACM},
 	year = {2020},
 	url = {https://dl.acm.org/doi/pdf/10.1145/3379479},
+	disussion_url = {https://github.com/net4people/bbs/issues/96},
 }
 
 @article{Sharma2020a,
@@ -778,6 +803,7 @@
 	year = {2020},
 	pages = {243--263},
 	url = {https://petsymposium.org/2020/files/papers/issue3/popets-2020-0051.pdf},
+	discussion_url = {https://github.com/net4people/bbs/issues/62},
 }
 
 @article{VanderSloot2020a,
@@ -790,6 +816,7 @@
 	year = {2020},
 	pages = {321--335},
 	url = {https://petsymposium.org/2020/files/papers/issue4/popets-2020-0073.pdf},
+	discussion_url = {https://github.com/net4people/bbs/issues/75},
 }
 
 @article{Minaei2020a,
@@ -802,6 +829,7 @@
 	year = {2020},
 	pages = {404--424},
 	url = {https://petsymposium.org/2020/files/papers/issue3/popets-2020-0058.pdf},
+	discussion_url = {https://github.com/net4people/bbs/issues/71},
 }
 
 @techreport{Robinson2013a,
@@ -819,6 +847,7 @@
 	publisher = {IEEE},
 	year = {2020},
 	url = {https://people.cs.umass.edu/~phillipa/papers/oakland2020.pdf},
+	discussion_url = {https://github.com/net4people/bbs/issues/52},
 }
 
 @inproceedings{Wang2020a,
@@ -828,6 +857,7 @@
 	publisher = {The Internet Society},
 	year = {2020},
 	url = {https://www.ndss-symposium.org/wp-content/uploads/2020/02/24083.pdf},
+	discussion_url = {https://github.com/net4people/bbs/issues/31},
 }
 
 @inproceedings{Nasr2020a,
@@ -837,6 +867,7 @@
 	publisher = {The Internet Society},
 	year = {2020},
 	url = {https://www.ndss-symposium.org/wp-content/uploads/2020/02/24340.pdf},
+	discussion_url = {https://github.com/net4people/bbs/issues/32},
 }
 
 @inproceedings{Frolov2020a,
@@ -846,6 +877,7 @@
 	publisher = {The Internet Society},
 	year = {2020},
 	url = {https://www.ndss-symposium.org/wp-content/uploads/2020/02/23087.pdf},
+	disussion_url = {https://github.com/net4people/bbs/issues/26},
 }
 
 @inproceedings{Raman2020a,
@@ -855,6 +887,7 @@
 	publisher = {The Internet Society},
 	year = {2020},
 	url = {https://censorbib.nymity.ch/pdf/Raman2020a.pdf},
+	disussion_url = {https://github.com/net4people/bbs/issues/34},
 }
 
 @inproceedings{Ramesh2020a,
@@ -864,6 +897,7 @@
 	publisher = {The Internet Society},
 	year = {2020},
 	url = {https://www.ndss-symposium.org/wp-content/uploads/2020/02/23098.pdf},
+	discussion_url = {https://github.com/net4people/bbs/issues/20},
 }
 
 @article{Oakley2020a,
@@ -899,6 +933,7 @@
 	publisher = {ACM},
 	year = {2019},
 	url = {https://jhalderm.com/pub/papers/conjure-ccs19.pdf},
+	disussion_url = {https://github.com/net4people/bbs/issues/18},
 }
 
 @inproceedings{Bock2019a,
@@ -908,6 +943,7 @@
 	publisher = {ACM},
 	year = {2019},
 	url = {https://censorbib.nymity.ch/pdf/Bock2019a.pdf},
+	disussion_url = {https://github.com/net4people/bbs/issues/23},
 }
 
 @inproceedings{Iszaevich2019a,
@@ -944,6 +980,7 @@
 	publisher = {USENIX},
 	year = {2019},
 	url = {https://www.usenix.org/system/files/foci19-paper_sheffey.pdf},
+	discussion_url = {https://github.com/net4people/bbs/issues/13},
 }
 
 @inproceedings{Chai2019a,
@@ -953,6 +990,7 @@
 	publisher = {USENIX},
 	year = {2019},
 	url = {https://www.usenix.org/system/files/foci19-paper_chai_update.pdf},
+	discussion_url = {https://github.com/net4people/bbs/issues/10},
 }
 
 @inproceedings{Knockel2019a,
@@ -971,6 +1009,7 @@
 	publisher = {USENIX},
 	year = {2019},
 	url = {https://www.usenix.org/system/files/foci19-paper_hoang.pdf},
+	disussion_url = {https://github.com/net4people/bbs/issues/12},
 }
 
 @inproceedings{Bocovich2017a,
@@ -998,6 +1037,7 @@
 	publisher = {The Internet Society},
 	year = {2019},
 	url = {https://tlsfingerprint.io/static/frolov2019.pdf},
+	discussion_url = {https://github.com/net4people/bbs/issues/54},
 }
 
 @inproceedings{Deng2017a,
@@ -1064,6 +1104,7 @@
 	publisher = {USENIX},
 	year = {2018},
 	url = {https://www.usenix.org/system/files/conference/usenixsecurity18/sec18-vandersloot.pdf},
+	disussion_url = {https://github.com/net4people/bbs/issues/2},
 }
 
 @inproceedings{Nisar2018a,
@@ -1456,6 +1497,7 @@
 	publisher = {ACM},
 	year = {2016},
 	url = {https://www.cypherpunks.ca/~iang/pubs/slitheen-ccs16.pdf},
+	discussion_url = {https://github.com/net4people/bbs/issues/51},
 }
 
 @inproceedings{Nasr2016a,
@@ -1555,6 +1597,7 @@
 	year = {2016},
 	pages = {4--20},
 	url = {https://censorbib.nymity.ch/pdf/Douglas2016a.pdf},
+	discussion_url = {https://github.com/net4people/bbs/issues/33},
 }
 
 @inproceedings{Scott2016a,
@@ -1707,6 +1750,7 @@
 	publisher = {ACM},
 	year = {2015},
 	url = {http://conferences2.sigcomm.org/imc/2015/papers/p445.pdf},
+	discussion_url = {https://github.com/net4people/bbs/issues/208},
 }
 
 @inproceedings{Holowczak2015a,
@@ -1951,6 +1995,7 @@
 	title = {{Internet} Censorship in {Iran}: A First Look},
 	year = {2013},
 	url = {https://censorbib.nymity.ch/pdf/Aryan2013a.pdf},
+	discussion_url = {https://github.com/net4people/bbs/issues/226},
 }
 
 @article{Aycock2008a,
@@ -2255,6 +2300,7 @@
 	title = {The Parrot is Dead: Observing Unobservable Network Communications},
 	year = {2013},
 	url = {https://people.cs.umass.edu/~amir/papers/parrot.pdf},
+	discussion_url = {https://github.com/net4people/bbs/issues/244},
 }
 
 @inproceedings{Houmansadr2014a,

--- a/references.bib
+++ b/references.bib
@@ -368,7 +368,7 @@
 	publisher = {},
 	year = {2023},
 	url = {https://www.petsymposium.org/foci/2023/foci-2023-0002.pdf},
-	disussion_url = {https://github.com/net4people/bbs/issues/322},
+	discussion_url = {https://github.com/net4people/bbs/issues/322},
 }
 
 @inproceedings{Fenske2023a,
@@ -450,7 +450,7 @@
 	publisher = {ACM},
 	year = {2022},
 	url = {https://dl.acm.org/doi/pdf/10.1145/3488932.3517419},
-	disussion_url = {https://github.com/net4people/bbs/issues/259},
+	discussion_url = {https://github.com/net4people/bbs/issues/259},
 }
 
 @inproceedings{Gosain2017b,
@@ -508,7 +508,7 @@
 	publisher = {ACM},
 	year = {2021},
 	url = {https://www.cs.jhu.edu/~gkaptch1/publications/ccs21_meteor.pdf},
-	disussion_url = {https://github.com/net4people/bbs/issues/104},
+	discussion_url = {https://github.com/net4people/bbs/issues/104},
 }
 
 @inproceedings{Xue2021a,
@@ -654,7 +654,7 @@
 	publisher = {ACM},
 	year = {2020},
 	url = {https://www.gsd.inesc-id.pt/~nsantos/papers/barradas_dicg20.pdf},
-	disussion_url = {https://github.com/net4people/bbs/issues/258},
+	discussion_url = {https://github.com/net4people/bbs/issues/258},
 }
 
 @inproceedings{Barradas2020a,
@@ -731,7 +731,7 @@
 	publisher = {USENIX},
 	year = {2020},
 	url = {https://www.usenix.org/system/files/foci20-paper-anonymous_0.pdf},
-	disussion_url = {https://github.com/net4people/bbs/issues/47},
+	discussion_url = {https://github.com/net4people/bbs/issues/47},
 }
 
 @inproceedings{Birtel2020a,
@@ -769,7 +769,7 @@
 	publisher = {USENIX},
 	year = {2020},
 	url = {https://www.usenix.org/system/files/foci20-paper-frolov.pdf},
-	disussion_url = {https://github.com/net4people/bbs/issues/50},
+	discussion_url = {https://github.com/net4people/bbs/issues/50},
 }
 
 @inproceedings{Singh2020a,
@@ -790,7 +790,7 @@
 	publisher = {ACM},
 	year = {2020},
 	url = {https://dl.acm.org/doi/pdf/10.1145/3379479},
-	disussion_url = {https://github.com/net4people/bbs/issues/96},
+	discussion_url = {https://github.com/net4people/bbs/issues/96},
 }
 
 @article{Sharma2020a,
@@ -877,7 +877,7 @@
 	publisher = {The Internet Society},
 	year = {2020},
 	url = {https://www.ndss-symposium.org/wp-content/uploads/2020/02/23087.pdf},
-	disussion_url = {https://github.com/net4people/bbs/issues/26},
+	discussion_url = {https://github.com/net4people/bbs/issues/26},
 }
 
 @inproceedings{Raman2020a,
@@ -887,7 +887,7 @@
 	publisher = {The Internet Society},
 	year = {2020},
 	url = {https://censorbib.nymity.ch/pdf/Raman2020a.pdf},
-	disussion_url = {https://github.com/net4people/bbs/issues/34},
+	discussion_url = {https://github.com/net4people/bbs/issues/34},
 }
 
 @inproceedings{Ramesh2020a,
@@ -933,7 +933,7 @@
 	publisher = {ACM},
 	year = {2019},
 	url = {https://jhalderm.com/pub/papers/conjure-ccs19.pdf},
-	disussion_url = {https://github.com/net4people/bbs/issues/18},
+	discussion_url = {https://github.com/net4people/bbs/issues/18},
 }
 
 @inproceedings{Bock2019a,
@@ -943,7 +943,7 @@
 	publisher = {ACM},
 	year = {2019},
 	url = {https://censorbib.nymity.ch/pdf/Bock2019a.pdf},
-	disussion_url = {https://github.com/net4people/bbs/issues/23},
+	discussion_url = {https://github.com/net4people/bbs/issues/23},
 }
 
 @inproceedings{Iszaevich2019a,
@@ -1009,7 +1009,7 @@
 	publisher = {USENIX},
 	year = {2019},
 	url = {https://www.usenix.org/system/files/foci19-paper_hoang.pdf},
-	disussion_url = {https://github.com/net4people/bbs/issues/12},
+	discussion_url = {https://github.com/net4people/bbs/issues/12},
 }
 
 @inproceedings{Bocovich2017a,
@@ -1104,7 +1104,7 @@
 	publisher = {USENIX},
 	year = {2018},
 	url = {https://www.usenix.org/system/files/conference/usenixsecurity18/sec18-vandersloot.pdf},
-	disussion_url = {https://github.com/net4people/bbs/issues/2},
+	discussion_url = {https://github.com/net4people/bbs/issues/2},
 }
 
 @inproceedings{Nisar2018a,

--- a/references.bib
+++ b/references.bib
@@ -1123,6 +1123,7 @@
 	publisher = {USENIX},
 	year = {2018},
 	url = {https://www.usenix.org/system/files/conference/foci18/foci18-paper-dunna.pdf},
+	discussion_url = {https://groups.google.com/g/traffic-obf/c/-z0gzKONGtI},
 }
 
 @inproceedings{Manfredi2018a,


### PR DESCRIPTION
This pull request adds:

* All reading group links on Net4People BBS to date (with the label "reading group" that are open: https://github.com/net4people/bbs/issues?q=is%3Aissue+is%3Aopen+label%3A%22reading+group%22);
* and one reading group link on traffic-obf mailing list.