### PR TITLE
TLS record fragmentation

### DIFF
--- a/references.bib
+++ b/references.bib
@@ -160,7 +160,7 @@
 
 @inproceedings{Niere2023a,
 	author = {Niklas Niere and Sven Hebrok and Juraj Somorovsky and Robert Merget},
-	title = {Poster: Circumventing the GFW with TLS Record Fragmentation},
+	title = {Poster: Circumventing the {GFW} with {TLS} Record Fragmentation},
 	booktitle = {Computer and Communications Security},
 	publisher = {ACM},
 	year = {2023},

--- a/references.bib
+++ b/references.bib
@@ -158,6 +158,16 @@
 	discussion_url = {https://github.com/net4people/bbs/issues/312},
 }
 
+@inproceedings{Niere2023a,
+	author = {Niklas Niere and Sven Hebrok and Juraj Somorovsky and Robert Merget},
+	title = {Poster: Circumventing the GFW with TLS Record Fragmentation},
+	booktitle = {Computer and Communications Security},
+	publisher = {ACM},
+	year = {2023},
+	url = {https://dl.acm.org/doi/pdf/10.1145/3576915.3624372},
+	discussion_url = {https://github.com/net4people/bbs/issues/308},
+}
+
 @article{Ververis2023a,
 	author = {Vasilis Ververis and Lucas Lasota and Tatiana Ermakova and Benjamin Fabian},
 	title = {Website blocking in the {European} {Union}: Network interference from the perspective of {Open} {Internet}},


### PR DESCRIPTION
Poster publication at ACM CCS 2023 about TLS record fragmentation.

TLS record fragmentation successfully evades censors (also discussed at net4people) and is widely supported by servers.

I also wrote a blogpost about it which I find more accessible but I was unsure whether and, if yes, how to include it:
https://upb-syssec.github.io/blog/2023/record-fragmentation/