### PR TITLE
Replace broken link.

### DIFF
--- a/references.bib
+++ b/references.bib
@@ -164,7 +164,7 @@
 	booktitle = {Computer and Communications Security},
 	publisher = {ACM},
 	year = {2023},
-	url = {https://dl.acm.org/doi/pdf/10.1145/3576915.3624372},
+	url = {https://nerd2.nrw/wp-content/uploads/2024/05/3576915.3624372.pdf},
 	discussion_url = {https://github.com/net4people/bbs/issues/308},
 }
 


### PR DESCRIPTION
As they say, if a link points to ACM, is it even a real link?