### PR TITLE
replacing 2 broken links

### DIFF
--- a/references.bib
+++ b/references.bib
@@ -2378,7 +2378,7 @@
 	booktitle = {Securing and Trusting Internet Names},
 	year = {2012},
 	publisher = {National Physical Laboratory},
-	url = {https://www.icsi.berkeley.edu/pubs/networking/dnspoisoning12.pdf},
+	url = {https://www.cs.albany.edu/~mariya/courses/csi516F19/papers/holdon.pdf},
 }
 
 @inproceedings{Dyer2013a,
@@ -2945,7 +2945,7 @@
 	booktitle = {Network and Distributed System Security},
 	publisher = {The Internet Society},
 	year = {2009},
-	url = {https://www.icsi.berkeley.edu/pubs/networking/ndss09-resets.pdf},
+	url = {https://www.ndss-symposium.org/wp-content/uploads/2017/09/weav.pdf},
 }
 
 @inproceedings{Weinberg2012a,


### PR DESCRIPTION
Noticed that icsi.berkeley.edu is no longer hosting the papers and added alternative links to them.