### PR TITLE
Make border radius 25% instead.

### DIFF
--- a/src/header.go
+++ b/src/header.go
@@ -84,7 +84,7 @@ const headerTemplate = `
     height: 1em;
     width: 1em;
     display: inline-block;
-    border-radius: 50%;
+    border-radius: 25%;
     transition: background-color 0.3s ease;
     padding: 0.5em;
     overflow: visible;


### PR DESCRIPTION
Otherwise WebKit is cutting off parts of the icons.