### PR TITLE
Add five FOCI'25 papers.

### DIFF
--- a/references.bib
+++ b/references.bib
@@ -17,7 +17,7 @@
 }
 
 @inproceedings{Vilalonga2025a,
-	author = {Afonso Vilalonga and Kevin Gallagher and João Resende and Osman Yagan and Henrique Domingos},
+	author = {Afonso Vilalonga and Kevin Gallagher and Osman Yaǧan and João S. Resende and Henrique Domingos},
 	title = {Extended Abstract: Using {TURN} Servers for Censorship Evasion},
 	booktitle = {Free and Open Communications on the Internet},
 	publisher = {},

--- a/references.bib
+++ b/references.bib
@@ -1,3 +1,48 @@
+@inproceedings{Wang2025a,
+	author = {Wayne Wang and Diwen Xue and Piyush Kumar and Ayush Mishra and Anonymous and Roya Ensafi},
+	title = {Is Custom Congestion Control a Bad Idea for Circumvention Tools?},
+	booktitle = {Free and Open Communications on the Internet},
+	publisher = {},
+	year = {2025},
+	url = {https://www.petsymposium.org/foci/2025/foci-2025-0001.pdf}
+}
+
+@inproceedings{Lange2025a,
+	author = {Felix Lange and Niklas Niere and Jonathan von Niessen and Dennis Suermann and Nico Heitmann and Juraj Somorovsky},
+	title = {I(ra)nconsistencies: Novel Insights into {Iran}'s Censorship},
+	booktitle = {Free and Open Communications on the Internet},
+	publisher = {},
+	year = {2025},
+	url = {https://www.petsymposium.org/foci/2025/foci-2025-0002.pdf}
+}
+
+@inproceedings{Vilalonga2025a,
+	author = {Afonso Vilalonga and Kevin Gallagher and João Resende and Osman Yagan and Henrique Domingos},
+	title = {Extended Abstract: Using {TURN} Servers for Censorship Evasion},
+	booktitle = {Free and Open Communications on the Internet},
+	publisher = {},
+	year = {2025},
+	url = {https://www.petsymposium.org/foci/2025/foci-2025-0003.pdf}
+}
+
+@inproceedings{Rodriguez2025a,
+	author = {Esther Rodriguez and Lobsang Gyatso and Tenzin Thayai and Jedidiah R. Crandall},
+	title = {Revisiting {BAT} Browsers: Protecting At-Risk Populations from Surveillance, Censorship, and Targeted Attacks},
+	booktitle = {Free and Open Communications on the Internet},
+	publisher = {},
+	year = {2025},
+	url = {https://www.petsymposium.org/foci/2025/foci-2025-0004.pdf}
+}
+
+@inproceedings{Habib2025a,
+	author = {Sana Habib and Mohammad Taha Khan and Jedidiah R. Crandall},
+	title = {Examining Leading {Pakistani} Mobile Apps},
+	booktitle = {Free and Open Communications on the Internet},
+	publisher = {},
+	year = {2025},
+	url = {https://www.petsymposium.org/foci/2025/foci-2025-0005.pdf}
+}
+
 @inproceedings{Kamali2025a,
 	author = {Sina Kamali and Diogo Barradas},
 	title = {Anix: Anonymous Blackout-Resistant Microblogging with Message Endorsing},


### PR DESCRIPTION
This pull request adds five FOCI'25 papers.

* Publication page: https://www.petsymposium.org/foci/2025/
* BBS discussion: https://github.com/net4people/bbs/issues/450