### PR TITLE
Add two NDSS'25 papers.

### DIFF
--- a/references.bib
+++ b/references.bib
@@ -1,3 +1,21 @@
+@inproceedings{Fan2025a,
+	author = {Shencha Fan and Jackson Sippe and Sakamoto San and Jade Sheffey and David Fifield and Amir Houmansadr and Elson Wedwards and Eric Wustrow},
+	title = {{Wallbleed}: A Memory Disclosure Vulnerability in the {Great Firewall} of {China}},
+	booktitle = {Network and Distributed System Security},
+	publisher = {The Internet Society},
+	year = {2025},
+	url = {https://gfw.report/publications/ndss25/data/paper/wallbleed.pdf},
+}
+
+@inproceedings{Xue2025a,
+	author = {Diwen Xue and Robert Stanley and Piyush Kumar and Roya Ensafi},
+	title = {The Discriminative Power of Cross-layer {RTT}s in Fingerprinting Proxy Traffic},
+	booktitle = {Network and Distributed System Security},
+	publisher = {The Internet Society},
+	year = {2025},
+	url = {https://www.ndss-symposium.org/wp-content/uploads/2025-966-paper.pdf},
+}
+
 @inproceedings{Wang2025a,
 	author = {Wayne Wang and Diwen Xue and Piyush Kumar and Ayush Mishra and Anonymous and Roya Ensafi},
 	title = {Is Custom Congestion Control a Bad Idea for Circumvention Tools?},

--- a/references.bib
+++ b/references.bib
@@ -5,6 +5,7 @@
 	publisher = {The Internet Society},
 	year = {2025},
 	url = {https://gfw.report/publications/ndss25/data/paper/wallbleed.pdf},
+	discussion_url = {https://github.com/net4people/bbs/issues/456},
 }
 
 @inproceedings{Xue2025a,


### PR DESCRIPTION
This PR adds two NDSS'25 papers:

* The Discriminative Power of Cross-layer {RTT}s in Fingerprinting Proxy Traffic
* Wallbleed: A Memory Disclosure Vulnerability in the Great Firewall of China (Homepage: https://gfw.report/publications/ndss25/en/)

