### PR TITLE
Add four S&P'25 papers and two classic IDS papers.

### DIFF
--- a/references.bib
+++ b/references.bib
@@ -6,6 +6,14 @@
 }
 
 @inproceedings{Handley2001a,
+  author={Mark Handley and Vern Paxson and Christian Kreibich},
+  title={Network Intrusion Detection: Evasion, Traffic Normalization, and {End-to-End} Protocol Semantics},
+  booktitle = {USENIX Security Symposium},
+  publisher = {USENIX},
+  year = {2001},
+  url = {https://www.usenix.org/legacy/events/sec01/full_papers/handley/handley.pdf},
+}
+
 @inproceedings{Wu2025a,
     author = {Mingshi Wu and Ali Zohaib and Zakir Durumeric and Amir Houmansadr and Eric Wustrow},
     title = {A Wall Behind A Wall: Emerging Regional Censorship in {China}},


### PR DESCRIPTION
This pull request adds four S&P'25 papers: https://www.ieee-security.org/TC/SP2025/program.html.

It also adds two important and classic Intrusion Detection System Evasion papers, which has served as the foundation of a brunch of censorship circumvention strategies:

* [Insertion, Evasion, and Denial of Service: Eluding Network Intrusion Detection](https://www.icir.org/vern/Ptacek-Newsham-Evasion-98.pdf)
* [Network Intrusion Detection: Evasion, Traffic Normalization, and End-to-End Protocol Semantics](https://www.usenix.org/legacy/events/sec01/full_papers/handley/handley.pdf)