### PR TITLE
Add ten FOCI'25 issue 2 papers.

### DIFF
--- a/references.bib
+++ b/references.bib
@@ -1,3 +1,111 @@
+@inproceedings{Sheffey2025a,
+    author = {Jade Sheffey and Ali Zohaib and Dayeon Kang and Zakir Durumeric and Amir Houmansadr and Qiang Wu},
+    title = {Extended Abstract: I’ll Shake Your Hand: What Happens After {DNS} Poisoning},
+    booktitle = {Free and Open Communications on the Internet},
+    publisher = {},
+    year = {2025},
+    url = {https://petsymposium.org/foci/2025/foci-2025-0015.pdf},
+}
+
+@inproceedings{Höller2025a,
+    author = {Tobias Höller and René Mayrhofer},
+    title = {Evaluating Onion Address Collection Methods},
+    booktitle = {Free and Open Communications on the Internet},
+    publisher = {},
+    year = {2025},
+    url = {https://petsymposium.org/foci/2025/foci-2025-0009.pdf},
+}
+
+@inproceedings{Mixon-Baca2025a,
+    author = {Benjamin Mixon-Baca and Jeffrey Knockel and Jedidiah R. Crandall},
+    title = {Hidden Links: Analyzing Secret Families of {VPN} Apps},
+    booktitle = {Free and Open Communications on the Internet},
+    publisher = {},
+    year = {2025},
+    url = {https://petsymposium.org/foci/2025/foci-2025-0008.pdf},
+}
+
+@inproceedings{Sivan-Sevilla2025a,
+    author = {Ido Sivan-Sevilla and Parthav Poudel},
+    title = {Probing the third-party infrastructure of digital news on the Web},
+    booktitle = {Free and Open Communications on the Internet},
+    publisher = {},
+    year = {2025},
+    url = {https://petsymposium.org/foci/2025/foci-2025-0017.pdf},
+}
+
+@inproceedings{Lipphardt2025a,
+    author = {Friedemann Lipphardt and Malte Tashiro and Romain Fontugne},
+    title = {1-800-Censorship: Analyzing internet censorship data using the Internet Yellow Pages},
+    booktitle = {Free and Open Communications on the Internet},
+    publisher = {},
+    year = {2025},
+    url = {https://petsymposium.org/foci/2025/foci-2025-0007.pdf},
+}
+
+@inproceedings{Niere2025b,
+    author = {Niklas Niere and Felix Lange and Nico Heitmann and Juraj Somorovsky},
+    title = {Encrypted Client Hello ({ECH}) in Censorship Circumvention},
+    booktitle = {Free and Open Communications on the Internet},
+    publisher = {},
+    year = {2025},
+    url = {https://petsymposium.org/foci/2025/foci-2025-0016.pdf},
+}
+
+@inproceedings{Vines2025a,
+    author = {Paul Vines},
+    title = {Extended Abstract: Nobody’s Fault but Mine: Using Unauthenticated Unidirectional Pushes for Client Update},
+    booktitle = {Free and Open Communications on the Internet},
+    publisher = {},
+    year = {2025},
+    url = {https://petsymposium.org/foci/2025/foci-2025-0012.pdf},
+}
+
+@inproceedings{Wilson2025a,
+    author = {Sarah Wilson and Stella Tian and Sina Kamali},
+    title = {Extended Abstract: Shaperd: Easily Adoptable Real-Time Traffic Shaper for Fully Encrypted Protocols},
+    booktitle = {Free and Open Communications on the Internet},
+    publisher = {},
+    year = {2025},
+    url = {https://petsymposium.org/foci/2025/foci-2025-0010.pdf},
+}
+
+@inproceedings{Midtlien2025a,
+    author = {Theodor Signebøen Midtlien and David Palma},
+    title = {Fingerprint-resistant {DTLS} for usage in Snowflake},
+    booktitle = {Free and Open Communications on the Internet},
+    publisher = {},
+    year = {2025},
+    url = {https://petsymposium.org/foci/2025/foci-2025-0006.pdf},
+}
+
+@inproceedings{Umesh2025a,
+    author = {Harshith Umesh and Alden W. Jackson},
+    title = {An Improved {BGP} Internet Graph for Optimizing Refraction Proxy Placement},
+    booktitle = {Free and Open Communications on the Internet},
+    publisher = {},
+    year = {2025},
+    url = {https://petsymposium.org/foci/2025/foci-2025-0014.pdf},
+}
+
+@inproceedings{Pereira2025a,
+    author = {Vitor Pereira and Ahmed Irfan and Vinod Yegneswaran and Nick Feamster and Prateek Mittal and Vitaly Shmatikov},
+    title = {Position Paper: A Case for Machine-Checked Verification of Circumvention Systems},
+    booktitle = {Free and Open Communications on the Internet},
+    publisher = {},
+    year = {2025},
+    url = {https://petsymposium.org/foci/2025/foci-2025-0013.pdf},
+}
+
+@inproceedings{Pereira2025b,
+    author = {Hugo Santos Pereira and Afonso Vilalonga and Kevin Gallagher and Henrique Domingos},
+    title = {Extended Abstract: Traffic Shaping for Network Protocols: A Modular and Developer-Friendly Framework},
+    booktitle = {Free and Open Communications on the Internet},
+    publisher = {},
+    year = {2025},
+    url = {https://petsymposium.org/foci/2025/foci-2025-0011.pdf},
+}
+
 @article{Chen2019a,
 	author = {Yuyu Chen and David Y. Yang},
 	title = {The Impact of Media Censorship: 1984 or {Brave New World}?},


### PR DESCRIPTION
This pull request adds ten FOCI'25 issue 2 papers. Note that I only added papers relevant to Internet censorship, and excluded papers only relevant to anonymity.

Refs:
* https://petsymposium.org/foci/2025/#issue2
* https://github.com/net4people/bbs/issues/500