### PR TITLE
Add USENIX Security 2025 paper on QUIC censorship

### DIFF
--- a/references.bib
+++ b/references.bib
@@ -134,6 +134,15 @@
 	url = {https://cs.uwaterloo.ca/~dbarrada/papers/kamali-sp25.pdf},
 }
 
+@inproceedings{Zohaib2025a,
+	author = {Ali Zohaib and Qiang Zao and Jackson Sippe and Abdulrahman Alaraj and Amir Houmansadr and Zakir Durumeric and Eric Wustrow},
+	booktitle = {USENIX Security Symposium},
+	publisher = {USENIX},
+	title = {Exposing and Circumventing {SNI}-based {QUIC} Censorship of the {Great Firewall} of {China}},
+	year = {2025},
+	url = {https://gfw.report/publications/usenixsecurity25/data/paper/quic-sni.pdf},
+}
+
 @article{Cheng2022a,
 	author = {Yanan Cheng and Yali Liu and Chao Li and Zhaoxin Zhang and Ning Li and Yuejin Du},
 	title = {In-Depth Evaluation of the Impact of National-Level {DNS} Filtering on {DNS} Resolvers over Space and Time},

--- a/references.bib
+++ b/references.bib
@@ -141,6 +141,7 @@
 	title = {Exposing and Circumventing {SNI}-based {QUIC} Censorship of the {Great Firewall} of {China}},
 	year = {2025},
 	url = {https://gfw.report/publications/usenixsecurity25/data/paper/quic-sni.pdf},
+	discussion_url = {https://github.com/net4people/bbs/issues/505},
 }
 
 @article{Cheng2022a,


### PR DESCRIPTION
This pull request adds the most recent article from [GFW Report](https://gfw.report/en/) on QUIC censorship. I included the link to the net4people discussion on this article.

Ref:
[Exposing and Circumventing SNI-based QUIC Censorship of the Great Firewall of China
](https://gfw.report/publications/usenixsecurity25/en/)

https://github.com/net4people/bbs/issues/505
