### PR TITLE
Added 2 More USENIX Papers

### DIFF
--- a/references.bib
+++ b/references.bib
@@ -1,3 +1,21 @@
+@inproceedings{Wails2025a,
+	author={Ryan Wails and Rob Jansen and Aaron Johnson and Micah Sherr},
+	title={Censorship Evasion with Unidentified Protocol Generation},
+	booktitle = {USENIX Security Symposium},
+	publisher = {USENIX},
+	year = {2025},
+	url = {https://www.usenix.org/system/files/usenixsecurity25-wails.pdf},
+}
+
+@inproceedings{Tai2025a,
+	author={Jonas Tai and Karthik Nishanth Sengottuvelavan and Peter Whiting and Nguyen Phong Hoang},
+	title={IRBlock: A Large-Scale Measurement Study of the Great Firewall of Iran},
+	booktitle = {USENIX Security Symposium},
+	publisher = {USENIX},
+	year = {2025},
+	url = {https://www.usenix.org/system/files/usenixsecurity25-tai.pdf},
+}
+
 @inproceedings{Sheffey2025a,
     author = {Jade Sheffey and Ali Zohaib and Dayeon Kang and Zakir Durumeric and Amir Houmansadr and Qiang Wu},
     title = {Extended Abstract: I’ll Shake Your Hand: What Happens After {DNS} Poisoning},


### PR DESCRIPTION
Added 2 more USENIX papers. They can be found [here](https://www.usenix.org/conference/usenixsecurity25/technical-sessions) on Wed August 13, 1-2:30pm Track 1. There might be other applicable papers in this section but I think these (and the QUIC paper from another pr) are the most obviously applicable.