### PR TITLE
Clean up formatting and remove reference.

### DIFF
--- a/references.bib
+++ b/references.bib
@@ -114,19 +114,19 @@
 }
 
 @inproceedings{Kirchner2025a,
-	author = {Kirchner, Robin and Tsoukaladelis, Chris and Johns, Martin and Nikiforakis, Nick},
-	title = {The Power to Never Be Wrong: Evasions and Anachronistic Attacks Against Web Archives},
-	booktitle = {Proceedings of the 2025 ACM SIGSAC Conference on Computer and Communications Security},
-	publisher = {Association for Computing Machinery},
+	author = {Robin Kirchner and Chris Tsoukaladelis and Martin Johns and Nick Nikiforakis},
+	title = {The Power to Never Be Wrong: Evasions and Anachronistic Attacks Against {Web} Archives},
+	booktitle = {Computer and Communications Security},
+	publisher = {ACM},
 	year = {2025},
 	url = {https://dl.acm.org/doi/epdf/10.1145/3719027.3765051},
 }
 
 @inproceedings{Inyangson2025a,
-	author = {Inyangson, David and Radway, Sarah and Jois, Tushar M. and Fazio, Nelly and Mickens, James},
-	title = {Amigo: Secure Group Mesh Messaging in Realistic Protest Settings},
-	booktitle = {Proceedings of the 2025 ACM SIGSAC Conference on Computer and Communications Security},
-	publisher = {Association for Computing Machinery},
+	author = {David Inyangson and Sarah Radway and Tushar M. Jois and Nelly Fazio and James Mickens},
+	title = {{Amigo}: Secure Group Mesh Messaging in Realistic Protest Settings},
+	booktitle = {Computer and Communications Security},
+	publisher = {ACM},
 	year = {2025},
 	url = {https://dl.acm.org/doi/epdf/10.1145/3719027.3765133},
 }
@@ -425,21 +425,12 @@
 }
 
 @inproceedings{Bhaskar2024a,
-	author = {Bhaskar, Abhishek and Pearce, Paul},
-	booktitle = {Proceedings of the 2024 on ACM SIGSAC Conference on Computer and Communications Security},
-	publisher = {Association for Computing Machinery},
+	author = {Abhishek Bhaskar and Paul Pearce},
 	title = {Understanding Routing-Induced Censorship Changes Globally},
+	booktitle = {Computer and Communications Security},
+	publisher = {ACM},
 	year = {2024},
 	url = {https://dl.acm.org/doi/epdf/10.1145/3658644.3670336},
-}
-
-@inproceedings{Jois2024a,
-	author = {Jois, Tushar M. and Beck, Gabrielle and Kaptchuk, Gabriel},
-	title = {Pulsar: Secure Steganography for Diffusion Models},
-	booktitle = {Proceedings of the 2024 on ACM SIGSAC Conference on Computer and Communications Security},
-	publisher = {Association for Computing Machinery},
-	year = {2024},
-	url = {https://dl.acm.org/doi/epdf/10.1145/3658644.3690218},
 }
 
 @inproceedings{Zillien2024a,


### PR DESCRIPTION
The 2024 Jois paper is about steganography. While quite similar, I've been avoiding adding steganography work because there's so much of it and I wanted to stay focused on (anti-)censorship.