### PR TITLE
Deploy to fly.io and Tigris.

### DIFF
--- a/.github/workflows/deploy-website.yaml
+++ b/.github/workflows/deploy-website.yaml
@@ -4,9 +4,6 @@ on:
     branches:
       master
 
-permissions:
-  contents: write
-
 jobs:
   deploy-website:
     runs-on: ubuntu-latest
@@ -14,15 +11,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install and Build
-        run: |
-          go build -C src -o ../compiler
-          mkdir build
-          mv assets build
-          ./compiler -path references.bib > build/index.html
+      - name: Set up flyctl
+        uses: superfly/flyctl-actions/setup-flyctl@master
 
-      - name: Deploy
-        uses: JamesIves/github-pages-deploy-action@v4
-        with:
-          # Must be identical to where we wrote the HTML to.
-          folder: build
+      - name: Deploy to fly.io
+        run: flyctl deploy
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM golang:1.26-alpine AS builder
+WORKDIR /app
+COPY src/ ./src/
+COPY references.bib .
+COPY assets/ ./assets/
+RUN go build -C src -mod=vendor -o ../compiler
+RUN ./compiler -path references.bib > index.html
+
+FROM nginx:alpine
+COPY --from=builder /app/assets /usr/share/nginx/html/assets
+COPY --from=builder /app/index.html /usr/share/nginx/html/index.html

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,22 @@
+# fly.toml app configuration file generated for censorbib on 2026-06-16T12:27:53-05:00
+#
+# See https://fly.io/docs/reference/configuration/ for information about how to use this file.
+#
+
+app = 'censorbib'
+primary_region = 'ord'
+
+[build]
+
+[http_service]
+  internal_port = 80
+  force_https = true
+  auto_stop_machines = 'stop'
+  auto_start_machines = true
+  min_machines_running = 0
+  processes = ['app']
+
+[[vm]]
+  memory = '256mb'
+  cpus = 1
+  memory_mb = 256

--- a/src/html.go
+++ b/src/html.go
@@ -30,7 +30,7 @@ var bibEntryTemplate = template.Must(template.New("bib-entry").Parse(`<li id="{{
 <span class="icons">
 {{if .DiscussionURL}}<a href="{{.DiscussionURL}}"><img class="icon" title="Online discussion" src="assets/discussion-icon.svg" alt="Discussion icon"></a>{{end}}
 <a href="{{.URL}}"><img class="icon" title="Download paper" src="assets/pdf-icon.svg" alt="Download icon"></a>
-<a href="https://censorbib.nymity.ch/pdf/{{.CiteName}}.pdf"><img class="icon" title="Download cached paper" src="assets/cache-icon.svg" alt="Cached download icon"></a>
+<a href="https://censorbib-papers.t3.tigrisfiles.io/{{.CiteName}}.pdf"><img class="icon" title="Download cached paper" src="assets/cache-icon.svg" alt="Cached download icon"></a>
 <a href="#bibtex-{{.CiteName}}" class="bibtex-link" data-reference="{{.CiteName}}" title="Show BibTeX" aria-label="Show BibTeX for {{.Title}}"><img class="icon" src="assets/bibtex-icon.svg" alt="BibTeX icon"></a>
 <a href="#{{.CiteName}}"><img class="icon" title="Link to paper" src="assets/link-icon.svg" alt="Paper link icon"></a>
 </span>


### PR DESCRIPTION
So far, we've been deploying CensorBib to GitHub pages (the static HTML/JS) and my personal web server (for pdfs). This worked okay but I'm not interested in hosting these pdfs myself anymore and the GitHub pages setup is a bit janky.

This commit deploys CensorBib to fly.io and hosts papers on Tigris. Fly.io gives us more control over deployment and availability regions whereas Tigris is a good fit for object storage. For now, I'm manually pushing pdfs to Tigris but I'd like to automate this too some time soon.