### PR TITLE
Redirect legacy URLs.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,5 +7,6 @@ RUN go build -C src -mod=vendor -o ../compiler
 RUN ./compiler -path references.bib > index.html
 
 FROM nginx:alpine
+COPY config/nginx.conf /etc/nginx/conf.d/default.conf
 COPY --from=builder /app/assets /usr/share/nginx/html/assets
 COPY --from=builder /app/index.html /usr/share/nginx/html/index.html

--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -1,0 +1,21 @@
+server {
+    listen 80;
+    listen [::]:80;
+    server_name _;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # Before Tigris, papers were self-hosted at censorbib.nymity.ch/pdf/.
+    # To keep these legacy URLs working, we redirect them to Tigris.
+    location = /pdf {
+        return 301 https://censorbib-papers.t3.tigrisfiles.io/$is_args$args;
+    }
+    location ~ ^/pdf/(.*)$ {
+        return 301 https://censorbib-papers.t3.tigrisfiles.io/$1$is_args$args;
+    }
+
+    location / {
+        try_files $uri $uri/ =404;
+    }
+}


### PR DESCRIPTION
Before Tigris, I self-hosted research papers at censorbib.nymity.ch/pdf. To keep legacy URLs working, this PR adds a redirect to Tigris to the nginx config.