### PR TITLE
Add citation for Lenz et al. on internet censorship

### DIFF
--- a/references.bib
+++ b/references.bib
@@ -1,3 +1,16 @@
+@inproceedings{Lenz2026a,
+	title = {Digital Control: National Tactics of Internet Censorship},
+	author = {Julia Lenz and Simon Volpert and Sebastian Zillien and Philip Rünz and Luca Caviglione and Steffen Wendzel},
+    booktitle = {Proc. European Interdisciplinary Cybersecurity Conference (\textbf{EICC 2026})},
+    year = {2026},
+    pages = {67-87},
+    publisher = {Springer},
+    series = {CCIS},
+	volume = {3012},
+    doi = {10.1007/978-3-032-28957-5_5},
+    url = {https://doi.org/10.1007/978-3-032-28957-5_5}
+}
+
 @inproceedings{Alaraj2025a,
 	author = {Abdulrahman Alaraj and Eric Wustrow},
 	title = {Proxies as Sensors: Measuring Censorship of Refraction Networking in {Iran}},

--- a/references.bib
+++ b/references.bib
@@ -1,13 +1,9 @@
 @inproceedings{Lenz2026a,
 	title = {Digital Control: National Tactics of Internet Censorship},
 	author = {Julia Lenz and Simon Volpert and Sebastian Zillien and Philip Rünz and Luca Caviglione and Steffen Wendzel},
-    booktitle = {Proc. European Interdisciplinary Cybersecurity Conference (\textbf{EICC 2026})},
+    booktitle = {European Interdisciplinary Cybersecurity Conference},
     year = {2026},
-    pages = {67-87},
     publisher = {Springer},
-    series = {CCIS},
-	volume = {3012},
-    doi = {10.1007/978-3-032-28957-5_5},
     url = {https://doi.org/10.1007/978-3-032-28957-5_5}
 }
 


### PR DESCRIPTION
Please note that the \textbf{} around "EICC 2026" might not match your style. I noticed this too late.